### PR TITLE
advancedtls: Add system default CAs to config function

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -190,7 +190,7 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 			"client needs to provide custom verification mechanism if choose to skip default verification")
 	}
 	rootCAs := o.RootCACerts
-	if o.VType > SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil {
+	if o.VType < SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil {
 		// Set rootCAs to system default
 		systemRootCAs, err := x509.SystemCertPool()
 		if err != nil {
@@ -221,7 +221,7 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 			"server needs to provide custom verification mechanism if choose to skip default verification, but require client certificate(s)")
 	}
 	clientCAs := o.RootCACerts
-	if o.VType > SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil && o.RequireClientCert {
+	if o.VType < SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil && o.RequireClientCert {
 		// Set clientCAs to system default
 		systemRootCAs, err := x509.SystemCertPool()
 		if err != nil {

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -412,6 +412,11 @@ func TestClientServerHandshake(t *testing.T) {
 				VerifyPeer:        test.serverVerifyFunc,
 				VType:             test.serverVType,
 			}
+			servertConf, _ := serverOptions.config()
+			if serverOptions.VType < SkipVerification && serverOptions.RootCACerts == nil &&
+				serverOptions.GetRootCAs == nil && serverOptions.RequireClientCert && servertConf.ClientCAs == nil {
+				t.Fatalf("Failed to assign default certificate on the server side.")
+			}
 			go func(done chan credentials.AuthInfo, lis net.Listener, serverOptions *ServerOptions) {
 				serverRawConn, err := lis.Accept()
 				if err != nil {
@@ -449,6 +454,11 @@ func TestClientServerHandshake(t *testing.T) {
 					GetRootCAs:  test.clientGetRoot,
 				},
 				VType: test.clientVType,
+			}
+			clientConf, _ := clientOptions.config()
+			if clientOptions.VType < SkipVerification && clientOptions.RootCACerts == nil &&
+				clientOptions.GetRootCAs == nil && clientConf.RootCAs == nil {
+				t.Fatalf("Failed to assign default certificate on the client side.")
 			}
 			clientTLS, newClientErr := NewClientCreds(clientOptions)
 			if newClientErr != nil && test.clientExpectCreateError {


### PR DESCRIPTION
This adds system default certificate to `rootCAs` and `clientCAs`.